### PR TITLE
Fix to handle various line endings when calculating line limit (Issue #12)

### DIFF
--- a/app/helpers/bits_helper.rb
+++ b/app/helpers/bits_helper.rb
@@ -1,8 +1,8 @@
 module BitsHelper
   def limit_string( str, lineLimit = 5, charLimit = 1000 )
-    lines = str[0,charLimit].split "\n"
+    lines = str[0,charLimit].lines.to_a
     logger.info "lines = " + lines.inspect
-    retVal = lines[0..4].join "\n"
+    retVal = lines[0..4].join
 
     retVal += "\n[...]" if retVal.length < str.length
     return retVal

--- a/test/unit/helpers/bits_helper_test.rb
+++ b/test/unit/helpers/bits_helper_test.rb
@@ -1,4 +1,8 @@
 require 'test_helper'
 
 class BitsHelperTest < ActionView::TestCase
+  def test_limit_string_handles_special_line_endings
+    limited_string = limit_string("test\r\n")
+    assert_no_match /\.\.\./, limited_string
+  end
 end


### PR DESCRIPTION
Whilst you could trim extra characters from bits during input, this solves the original problem and also uses a slightly more reliable way of splitting up lines.

This is my first contribution to any open-source project, so please let me know if my commit message (or code) needs some improvement :)
