### PR TITLE
Add support to highlight vim script syntax

### DIFF
--- a/app/views/bits/_bit.html.haml
+++ b/app/views/bits/_bit.html.haml
@@ -1,4 +1,3 @@
-
 .bit.row
   .row
     .span8.row.header
@@ -18,7 +17,7 @@
 
   .row
     .span8.code
-      %pre.prettyprint.linenums= limit_string bit.code
+      %pre.prettyprint.linenums.lang-vim= limit_string bit.code
   - if bit.comments.count > 0
     .row
       .span8.comment-summary

--- a/vendor/assets/javascripts/google-code-prettify/lang-vim.js
+++ b/vendor/assets/javascripts/google-code-prettify/lang-vim.js
@@ -1,0 +1,44 @@
+/**
+ * @preserve Copyright (C) 2012 Kyo Nagashima
+ *
+ * LICENSE: http://hail2u.mit-license.org/2012
+ */
+
+/**
+ * @fileoverview
+ * Registers a language handler for Vim script.
+ *
+ *
+ * To use, include prettify.js and this file in your HTML page.
+ * Then put your code in an HTML tag like
+ *      <pre class="prettyprint lang-vim"></pre>
+ *
+ *
+ * @author kyo@haiil2u.net
+ */
+
+PR['registerLangHandler'](
+    PR['createSimpleLexer'](
+        [
+            // Whitespace
+            [PR['PR_PLAIN'], /^[\t\n\r \xA0\u2028\u2029]+/, null, '\t\n\r \xA0\u2028\u2029']
+        ],
+        [
+            // Double quoted string
+            [PR['PR_STRING'], /^\"[^\"\r\n]*?\"/],
+            // Single quoted string
+            [PR['PR_STRING'], /^\'[^\'\r\n]*?\'/],
+            // Line comment
+            [PR['PR_COMMENT'], /^[\"\u2018\u2019][^\r\n\u2028\u2029]*/],
+            // Keywords
+            [PR['PR_KEYWORD'], /^(?:function|endfunction|delfunction|return|call|let|unlet|lockvar|unlockvar|if|endif|else|elseif|while|endwhile|for|in|endfor|continue|break|try|endtry|catch|finally|throw|echo|ehon|echohl|echomsg|echoerr|execute|set|autocmd|augroup|[nvxsoilc]?(?:nore)?map|command)\b/i],
+            // Literal number
+            [PR['PR_LITERAL'], /^(?:\d+)/i],
+            // Identifier
+            [PR['PR_PLAIN'], /^(?:(?:[a-z]|_\w)[\w\:]*)/i],
+            // Punctuation
+            [PR['PR_PUNCTUATION'], /^[^\s\w\'\"]+/]
+        ]
+    ),
+    ['vim']
+);


### PR DESCRIPTION
Added `lang-vim` definition for Google prettify to nicely highlight vim lang, as this is Vimbits! :)

Please check that it works, it should, but I haven't tested thoroughly, thank you.
